### PR TITLE
Add pass keyword as code placeholder

### DIFF
--- a/FlaskWebProject/views.py
+++ b/FlaskWebProject/views.py
@@ -117,6 +117,7 @@ def _load_cache():
 
 def _save_cache(cache):
     # TODO: Save the cache, if it has changed
+    pass
 
 def _build_msal_app(cache=None, authority=None):
     # TODO: Return a ConfidentialClientApplication


### PR DESCRIPTION
If students deploys the starter code "as-is", no modifications, an error will appear.
![deployment-error](https://user-images.githubusercontent.com/75508473/101292304-58f55680-37d4-11eb-85d8-da88f7a15ea6.png)


This little change enables students to make a deployment of the starter code "as-is" to the Azure Portal. Landing at the login page.
![loginCMS](https://user-images.githubusercontent.com/75508473/101292311-66124580-37d4-11eb-8010-b64e5e8a321d.png)

